### PR TITLE
WebMidi.js implementation, some MIDI refactoring, some WIP features

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10946,11 +10946,6 @@
         "defaults": "^1.0.3"
       }
     },
-    "webmidi": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/webmidi/-/webmidi-2.5.1.tgz",
-      "integrity": "sha512-rX9/vBBSnSZR04ZZcLWCe/ujOizH9f/Q9HX11+Zw+HHwOy7edUTbbC3Axc2RjoiDQ2W7RkK1tY4yv0nYSfUcJg=="
-    },
     "webpack": {
       "version": "4.41.5",
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.41.5.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10946,6 +10946,11 @@
         "defaults": "^1.0.3"
       }
     },
+    "webmidi": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/webmidi/-/webmidi-2.5.1.tgz",
+      "integrity": "sha512-rX9/vBBSnSZR04ZZcLWCe/ujOizH9f/Q9HX11+Zw+HHwOy7edUTbbC3Axc2RjoiDQ2W7RkK1tY4yv0nYSfUcJg=="
+    },
     "webpack": {
       "version": "4.41.5",
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.41.5.tgz",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "tone": "^13.8.25",
     "vue": "^2.6.10",
     "vue-router": "^3.1.3",
-    "vuex": "^3.1.2"
+    "vuex": "^3.1.2",
+    "webmidi": "^2.5.1"
   },
   "devDependencies": {
     "@vue/cli-plugin-babel": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -12,8 +12,7 @@
     "tone": "^13.8.25",
     "vue": "^2.6.10",
     "vue-router": "^3.1.3",
-    "vuex": "^3.1.2",
-    "webmidi": "^2.5.1"
+    "vuex": "^3.1.2"
   },
   "devDependencies": {
     "@vue/cli-plugin-babel": "^4.1.0",

--- a/src/components/menu/Menu.vue
+++ b/src/components/menu/Menu.vue
@@ -44,11 +44,10 @@ export default {
       menuOptions: {
         themes: ["classic", "80s"],
         arpeggio: arpeggios,
-        angle: ["diatonic", "symetric"],
-        midi: ["toggle internal synth", "devices"]
+        angle: ["diatonic", "symetric"]
       },
       menuTree: [],
-      pickedMenuOption: ["gridsize", "arpeggio", "angle", "midi"],
+      pickedMenuOption: ["gridsize", "arpeggio", "angle"],
       chooseGridSize: false,
       inputOption: ""
     };
@@ -86,21 +85,12 @@ export default {
       if (option == "minor7" || option == "major7") {
         this.changeArpeggio(arpeggioNotes[option]);
       }
-
-      if (option == "toggle internal synth") {
-        this.toggleInternalSynth();
-      }
-
       this.menuTree.push(this.pickedMenuOption);
       this.pickedMenuOption = this.menuOptions[option];
     },
     changeArpeggio(newArpeggio) {
       this.$store.dispatch("changeArpeggio", newArpeggio);
       this.eventEmitter("createAllArs");
-      this.eventEmitter("closeModal");
-    },
-    toggleInternalSynth() {
-      this.eventEmitter("toggleInternalSynth");
       this.eventEmitter("closeModal");
     }
   },

--- a/src/components/menu/Menu.vue
+++ b/src/components/menu/Menu.vue
@@ -44,10 +44,11 @@ export default {
       menuOptions: {
         themes: ["classic", "80s"],
         arpeggio: arpeggios,
-        angle: ["diatonic", "symetric"]
+        angle: ["diatonic", "symetric"],
+        midi: ["toggle internal synth", "devices"]
       },
       menuTree: [],
-      pickedMenuOption: ["gridsize", "arpeggio", "angle"],
+      pickedMenuOption: ["gridsize", "arpeggio", "angle", "midi"],
       chooseGridSize: false,
       inputOption: ""
     };
@@ -85,12 +86,21 @@ export default {
       if (option == "minor7" || option == "major7") {
         this.changeArpeggio(arpeggioNotes[option]);
       }
+
+      if (option == "toggle internal synth") {
+        this.toggleInternalSynth();
+      }
+
       this.menuTree.push(this.pickedMenuOption);
       this.pickedMenuOption = this.menuOptions[option];
     },
     changeArpeggio(newArpeggio) {
       this.$store.dispatch("changeArpeggio", newArpeggio);
       this.eventEmitter("createAllArs");
+      this.eventEmitter("closeModal");
+    },
+    toggleInternalSynth() {
+      this.eventEmitter("toggleInternalSynth");
       this.eventEmitter("closeModal");
     }
   },

--- a/src/components/menu/MidiOutputs.vue
+++ b/src/components/menu/MidiOutputs.vue
@@ -12,7 +12,7 @@
 </template>
 
 <script>
-import { requestMIDIAccess } from "../../midi-service/midiService";
+import { midiOutputs, setOutputDevice } from "../../midi-service/midiService";
 export default {
   name: "MidiOut",
   data() {
@@ -20,16 +20,12 @@ export default {
       midiOutputs: []
     };
   },
-  mounted() {
-    this.getMidiOutputs();
+  async mounted() {
+    this.midiOutputs = await midiOutputs;
   },
-  methods: {
-    requestMIDIAccess,
-    getMidiOutputs() {
-      this.requestMIDIAccess().then(resp => (this.midiOutputs = resp));
-    },
-    setMidiOutput(payload) {
+  methods: { setMidiOutput(payload) {
       this.$store.dispatch("addMidiOutput", payload);
+      setOutputDevice(payload);
       localStorage.setItem("midiOutput", payload.name);
       this.$store.dispatch("modalIsOpen", false);
     }


### PR DESCRIPTION
I kept your idea of having a `midiService.js` file to handle all that stuff, and also kept `midiPlay` and `midiStop` functions but they work a bit differently now.
I figured since we're only ever playing one note at a time, we can take advantage of webmidi's `duration` parameter to automatically send `noteOff`s after the right amount of time determined by the bpm (I also added a multiplier variable so midi notes can be a certain percentage of a beat long, currently not user-controllable though) so to play notes we only ever need to use the `midiPlay` function
For stopping, I made `midiStop` send the `allNotesOff` message which could be nice if any glitch or something causes a note to hang. Since `midiPlay` handles `noteOff`s for the sequence the only time we need to call `midiStop` is when we actually want to stop any midi being sent (hitting the stop button or reaching the edge of the grid)
The updated `midiService.js` also keeps track of the midi device being sent to, rather than passing that as a parameter to `midiPlay`

Let me know what you think :)
